### PR TITLE
fix: Allow to customise sort field and order for resources

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -372,7 +372,7 @@ class DataProvider {
 
         if (queryType === 'GET_LIST') {
           queries.push({
-            query: this.getAllRecords({ resourceName, filter: newParams.filter }),
+            query: this.getAllRecords({ resourceName, filter: newParams.filter, sort: newParams.sort }),
             resourceName
           });
         } else if (queryType === 'GET_ONE') {
@@ -676,15 +676,15 @@ class DataProvider {
     }
   };
 
-  getAllRecords = ({ resourceName, filter = {} }) => {
+  getAllRecords = ({ resourceName, filter = {}, sort = { order: 'DESC' } }) => {
     return this.dataProvider('GET_LIST', resourceName, {
       pagination: { page: 1, perPage: 1 },
-      sort: { field: 'id', order: 'DESC' },
+      sort: sort,
       filter
     }).then(res => {
       return this.dataProvider('GET_LIST', resourceName, {
         pagination: { page: 1, perPage: res.total },
-        sort: { field: 'id', order: 'DESC' },
+        sort: sort,
         filter
       });
     });

--- a/src/index.js
+++ b/src/index.js
@@ -370,9 +370,22 @@ class DataProvider {
           newParams = { ...params };
         }
 
+        let sort = { field: 'id', sort: 'DESC' };
+        if (
+          newParams.sort &&
+          newParams.sort.field &&
+          resource.fields.indexOf(newParams.sort.field) !== -1
+        ) {
+          sort = newParams.sort;
+        }
+
         if (queryType === 'GET_LIST') {
           queries.push({
-            query: this.getAllRecords({ resourceName, filter: newParams.filter, sort: newParams.sort }),
+            query: this.getAllRecords({
+              resourceName,
+              filter: newParams.filter,
+              sort: sort
+            }),
             resourceName
           });
         } else if (queryType === 'GET_ONE') {


### PR DESCRIPTION
The [`sort`](https://marmelab.com/react-admin/List.html#default-sort-field) option in [`react-admin`](https://marmelab.com/react-admin) [`List`](https://marmelab.com/react-admin/List.html) component allows to customise the sort field and ordering. This is currently overwritten with `id` `DESC`. 

This PR makes it work with any field and order

Note: the default in `ra-data-hasura` is `id` `ASC` (when not specified), though the current default in `ra-resource-aggretator` is `id` `DESC`. This difference remains as it hasn't been changed in this PR
https://github.com/hasura/ra-data-hasura/blob/6458ae732f10cf74b102e6aae0325b4ffcc65200/src/index.js#L96